### PR TITLE
Update node version to node16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ inputs:
     required: true
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "main.js"
 
 branding:


### PR DESCRIPTION
Node12 is deprecated hence updating the node version to node16